### PR TITLE
Integrate project with CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+addons:
+  sonarcloud:
+    organization: "defra"
+
+language: java
+
+jdk:
+  - openjdk8
+
+# Travis CI uses shallow clone to speed up build times, but a truncated SCM
+# history may cause issues when SonarCloud computes blame data. To avoid this,
+# you can access the full SCM history with `depth: false`
+git:
+  depth: false
+
+script:
+  # the following command line builds the project, runs the tests with coverage and then execute the SonarCloud analysis
+  - ./mvnw clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_sroc-tcm-acceptance-tests
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # SROC TCM Acceptance tests
 
+[![Build Status](https://travis-ci.com/DEFRA/sroc-tcm-acceptance-tests.svg?branch=main)](https://travis-ci.com/DEFRA/sroc-tcm-acceptance-tests)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_sroc-tcm-acceptance-tests&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_sroc-tcm-acceptance-tests)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_sroc-tcm-acceptance-tests&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_sroc-tcm-acceptance-tests)
+[![Known Vulnerabilities](https://snyk.io/test/github/DEFRA/sroc-tcm-acceptance-tests/badge.svg)](https://snyk.io/test/github/DEFRA/sroc-tcm-acceptance-tests)
+[![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
+
 > Temporary project. Do not use as a basis for doing selenium tests with Java!
 
 The Strategic Review of Charging (SROC) Tactical Charging Module (TCM) is an internal tool built by Defra to support the calculation of charges related to various permitting regimes.

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,39 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Sets the path to the file which contains the execution data. -->
+                            <dataFile>target/jacoco.exec</dataFile>
+                            <!-- Sets the output directory for the code coverage report. -->
+                            <outputDirectory>target/jacoco</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+# Project key is required. You'll find it in the SonarCloud UI
+sonar.projectKey=DEFRA_sroc-tcm-acceptance-tests
+sonar.organization=defra
+
+# This is the name and version displayed in the SonarCloud UI
+sonar.projectName=sroc-tcm-acceptance-tests
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/DEFRA/sroc-service-team
+sonar.links.ci=https://travis-ci.com/DEFRA/sroc-tcm-acceptance-tests
+sonar.links.scm=https://github.com/DEFRA/sroc-tcm-acceptance-tests
+sonar.links.issue=https://github.com/DEFRA/sroc-service-team/issues


### PR DESCRIPTION
Even though this is a temporary project, and the bulk of the code comes from elsewhere we still want to follow healthy habits. Plus having CI will both flag just how many issues we have maintaining this code, and ensure changes we make don't prevent it from at least building.