### PR TITLE
Add headless option to config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 addons:
   sonarcloud:
     organization: "defra"
+  chrome: stable
 
 language: java
 
@@ -13,7 +14,25 @@ jdk:
 git:
   depth: false
 
+before_script:
+  # To support running selenium on Travis we have told Travis to install Chrome
+  # (see addons). You also need the chromedriver which Travis doesn't install.
+  # To make this 'future-proof' we use a couple of scripts to determine the
+  # current version of Chrome. We can then use this to work out the matching
+  # version of Chromedriver. Once we have that we download and unzip
+  # Chromedriver to our drivers/ folder ready for use in the script section.
+  #
+  # Thanks to https://travis-ci.community/u/sheean for his response which solved
+  # this problem for us
+  # https://travis-ci.community/t/how-to-setup-chromedriver-74-with-chrome-74-for-travis/2678/10
+  - CHROME_INSTALLED_VERSION=`google-chrome-stable --version | sed -E 's/(^Google Chrome |\.[0-9]+ )//g'`
+  - CHROMEDRIVER_VERSION=`curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_INSTALLED_VERSION"`
+  - curl "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip" -O
+  - unzip chromedriver_linux64.zip -d /home/travis/build/DEFRA/sroc-tcm-acceptance-tests/drivers
+
 script:
   # the following command line builds the project, runs the tests with coverage and then execute the SonarCloud analysis
-  - ./mvnw clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_sroc-tcm-acceptance-tests
+  - ./mvnw clean package org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_sroc-tcm-acceptance-tests
+  # confirm project is working by running our example test
+  - TCM_TEST_PASSWORD=password java -jar target/sroc-tcm-acceptance-tests.jar example.config.yml
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ From the root of the project run the following to confirm all is working
 TCM_TEST_PASSWORD=password java -jar target/sroc-tcm-acceptance-tests.jar example.config.yml
 ```
 
-If it is you should see Chrome open, and a quick search on Google take place. Blink, and you might miss it!
+If it is the project will perform a quick search on Google. The browser won't appear for this as the test is set to run headless.
 
 ## Configuration
 
@@ -72,14 +72,16 @@ To run the main test create a new config file. For example, create a file called
 
 ```yaml
 browser: chrome
+headless: false
 rootUrl: "https://url-of-tcm-dev-environment.gov.uk/"
 test: main
 ```
 
-You can create as many configuration files as you like mixing `browser` and `rootUrl`.
+You can create as many configuration files as you like mixing `browser`, `headless` and `rootUrl`.
 
 ```yaml
 browser: firefox
+headless: true
 rootUrl: "https://url-of-tcm-test-environment.gov.uk/"
 test: main
 ```
@@ -87,6 +89,7 @@ test: main
 Key things are
 
 - `browser:` only use the values `chrome` or `firefox`
+- `headless:` only use the values `true` or `false`. 
 - `rootUrl:` should be the base url for an environment, not something like `https://url-of-tcm-dev-environment.gov.uk/auth/sign_in`
 - `test:` should always be `main`. It's configurable only to support the [Confirm setup](#confirm-setup) step of the installation.
 

--- a/example.config.yml
+++ b/example.config.yml
@@ -1,3 +1,4 @@
 browser: chrome
+headless: true
 rootUrl: "https://www.google.co.uk/"
 test: example

--- a/src/main/java/uk/gov/defra/AcceptanceTestDriver.java
+++ b/src/main/java/uk/gov/defra/AcceptanceTestDriver.java
@@ -2,7 +2,9 @@ package uk.gov.defra;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -13,19 +15,17 @@ public class AcceptanceTestDriver {
     private WebDriver driver;
 
     private DriverName driverName;
+    private Boolean headless;
 
-    public enum DriverName {
+    private enum DriverName {
         chrome,
         gecko
     }
 
-    public AcceptanceTestDriver(String selectedBrowser) {
+    public AcceptanceTestDriver(String selectedBrowser, Boolean headless) {
+        this.headless = headless;
         determineDriverName(selectedBrowser);
         setDriverSystemProperty();
-    }
-
-    public DriverName getDriverName() {
-        return driverName;
     }
 
     public WebDriver getDriver() {
@@ -51,9 +51,19 @@ public class AcceptanceTestDriver {
     private String getDriverPath() {
         Path currentRelativePath = Paths.get("");
         Path currentDir = currentRelativePath.toAbsolutePath();
-        String filename = "drivers" + File.separatorChar + driverName.name() + "driver" + driverExtension();
+        String filename = "drivers" + File.separatorChar + driverName.name() + "driver" + getDriverExtension();
 
         return currentDir.resolve(filename).toString();
+    }
+
+    private String getDriverExtension() {
+        String extension = "";
+
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            extension = ".exe";
+        }
+
+        return extension;
     }
 
     private void setDriverSystemProperty() {
@@ -62,19 +72,23 @@ public class AcceptanceTestDriver {
 
     private void initialiseDriver() {
         if (driverName == DriverName.chrome) {
-            driver = new ChromeDriver();
+            driver = new ChromeDriver(getChromeOptions());
         } else {
-            driver = new FirefoxDriver();
+            driver = new FirefoxDriver(getFirefoxOptions());
         }
     }
 
-    private String driverExtension() {
-        String extension = "";
+    private ChromeOptions getChromeOptions() {
+        ChromeOptions options = new ChromeOptions();
+        options.setHeadless(headless);
 
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            extension = ".exe";
-        }
+        return options;
+    }
 
-        return extension;
+    private FirefoxOptions getFirefoxOptions() {
+        FirefoxOptions options = new FirefoxOptions();
+        options.setHeadless(headless);
+
+        return options;
     }
 }

--- a/src/main/java/uk/gov/defra/Configuration.java
+++ b/src/main/java/uk/gov/defra/Configuration.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 public class Configuration {
 
     private String browser;
+    private Boolean headless;
     private String rootUrl;
     private String test;
 
@@ -24,6 +25,14 @@ public class Configuration {
 
     public void setBrowser(String browser) {
         this.browser = browser;
+    }
+
+    public Boolean getHeadless() {
+        return headless;
+    }
+
+    public void setHeadless(Boolean headless) {
+        this.headless = headless;
     }
 
     public String getRootUrl() {

--- a/src/main/java/uk/gov/defra/tests/BaseTest.java
+++ b/src/main/java/uk/gov/defra/tests/BaseTest.java
@@ -11,7 +11,7 @@ public abstract class BaseTest implements TestInterface {
     protected WebDriver driver;
 
     public BaseTest(Configuration config) {
-        this.testDriver = new AcceptanceTestDriver(config.getBrowser());
+        this.testDriver = new AcceptanceTestDriver(config.getBrowser(), config.getHeadless());
         this.rootUrl = config.getRootUrl();
         this.driver = testDriver.getDriver();
     }

--- a/src/test/java/uk/gov/defra/AcceptanceTestDriverTest.java
+++ b/src/test/java/uk/gov/defra/AcceptanceTestDriverTest.java
@@ -60,7 +60,7 @@ class AcceptanceTestDriverTest {
      *
      * @throws Exception
      */
-    @Disabled
+    @Disabled("Test will only pass when it is the last test for this class. Awaiting a fix")
     @Test
     void Adds_exe_to_driver_path_in_webdriver_system_property_when_os_is_windows() throws Exception {
         restoreSystemProperties(() -> {

--- a/src/test/java/uk/gov/defra/AcceptanceTestDriverTest.java
+++ b/src/test/java/uk/gov/defra/AcceptanceTestDriverTest.java
@@ -1,5 +1,6 @@
 package uk.gov.defra;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemProperties;
@@ -8,47 +9,9 @@ import static org.junit.jupiter.api.Assertions.*;
 class AcceptanceTestDriverTest {
 
     @Test
-    void DriverName_is_chrome_when_browser_is_chrome() {
-        AcceptanceTestDriver subject = new AcceptanceTestDriver("chrome");
-
-        assertEquals(
-                AcceptanceTestDriver.DriverName.chrome,
-                subject.getDriverName()
-        );
-    }
-
-    @Test
-    void DriverName_is_gecko_when_browser_is_firefox() {
-        AcceptanceTestDriver subject = new AcceptanceTestDriver("firefox");
-
-        assertEquals(
-                AcceptanceTestDriver.DriverName.gecko,
-                subject.getDriverName()
-        );
-    }
-
-    @Test
-    void Ignores_case_of_browser_value_when_initialised() {
-        AcceptanceTestDriver subject = new AcceptanceTestDriver("CHROME");
-
-        assertEquals(
-                AcceptanceTestDriver.DriverName.chrome,
-                subject.getDriverName()
-        );
-    }
-
-    @Test
-    void Throws_IllegalArgumentException_when_browser_is_unrecognised() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> new AcceptanceTestDriver("safari")
-        );
-    }
-
-    @Test
     void Sets_webdriver_system_property_to_chromedriver_when_browser_is_chrome() throws Exception {
         restoreSystemProperties(() -> {
-            AcceptanceTestDriver subject = new AcceptanceTestDriver("chrome");
+            new AcceptanceTestDriver("chrome", true);
             assertTrue(
                     System.getProperty("webdriver.chrome.driver").endsWith("chromedriver")
             );
@@ -58,7 +21,7 @@ class AcceptanceTestDriverTest {
     @Test
     void Sets_webdriver_system_property_to_geckodriver_when_browser_is_firefox() throws Exception {
         restoreSystemProperties(() -> {
-            AcceptanceTestDriver subject = new AcceptanceTestDriver("firefox");
+            new AcceptanceTestDriver("firefox", true);
             assertTrue(
                     System.getProperty("webdriver.gecko.driver").endsWith("geckodriver")
             );
@@ -66,10 +29,44 @@ class AcceptanceTestDriverTest {
     }
 
     @Test
+    void Ignores_case_of_browser_value_when_initialised() throws Exception {
+        restoreSystemProperties(() -> {
+            new AcceptanceTestDriver("CHROME", true);
+            assertTrue(
+                    System.getProperty("webdriver.chrome.driver").endsWith("chromedriver")
+            );
+        });
+    }
+
+    @Test
+    void Throws_IllegalArgumentException_when_browser_is_unrecognised() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new AcceptanceTestDriver("safari", true)
+        );
+    }
+
+
+    /**
+     * Tests that .exe is added to the 'webdriver.[driver].driver' system property.
+     *
+     * Currently disabled because we found it was only passing if the tests were
+     * ordered such that this was last. It seems setting the system property
+     * to something else and then calling `Paths.get("");` breaks
+     * `java.nio.file.Paths.get()` for subsequent calls. This is even with
+     * SystemLambda resetting everything.
+     *
+     * Used for reference (but no solution) https://stackoverflow.com/a/37579227/6117745
+     *
+     * @throws Exception
+     */
+    @Disabled
+    @Test
     void Adds_exe_to_driver_path_in_webdriver_system_property_when_os_is_windows() throws Exception {
         restoreSystemProperties(() -> {
-            System.setProperty("os.name", "Windows 10");
-            AcceptanceTestDriver subject = new AcceptanceTestDriver("chrome");
+            System.setProperty("os.name", "Windows 8.1");
+            System.setProperty("os.version", "6.3");
+            AcceptanceTestDriver subject = new AcceptanceTestDriver("chrome", true);
             assertTrue(
                     System.getProperty("webdriver.chrome.driver").endsWith(".exe")
             );

--- a/src/test/java/uk/gov/defra/ConfigurationTest.java
+++ b/src/test/java/uk/gov/defra/ConfigurationTest.java
@@ -85,6 +85,7 @@ class ConfigurationTest {
         Configuration subject = Configuration.readConfigurationFile(absolutePath);
 
         assertEquals("chrome", subject.getBrowser());
+        assertEquals(true, subject.getHeadless());
         assertEquals("https://example.com", subject.getRootUrl());
         assertEquals("main", subject.getTest());
     }

--- a/src/test/resources/fixtures/valid.config.yml
+++ b/src/test/resources/fixtures/valid.config.yml
@@ -1,3 +1,4 @@
 browser: chrome
+headless: true
 rootUrl: "https://example.com"
 test: main


### PR DESCRIPTION
Both Chrome and Firefox can be driven in headless mode. This means the browser UI is not actually loaded and typically results in faster test times. This is because though the browser will still interact with the web service it doesn't have to render the page.

It should also mean we can actually run our example test in Travis as an extra check that nothing is broken!

N.B. Whilst in we did some housekeeping on the `AcceptanceTestDriver` making private and removing a getter we thought we needed for testing. We also have had to diable a test having spotted it's not actually behaving as expected.