### PR TITLE
Exclude manifest signature files from uber-jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.4</version>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
https://stackoverflow.com/a/6743609/6117745

In another branch and in an effort to decrypt the password from the 'test' we added a dependency it turns out is signed. When you combine a signed Jar into our uber-jar via the Maven shade plugin the signature no longer matches.

The top answer to resolve this is to exclude manifest signature files by adding a filter to the maven shade configuration. This also means I now know what these lines are doing in the pom.xml!