### PR TITLE
Fix example test used in Travis CI

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -1,4 +1,4 @@
 browser: chrome
 headless: true
-rootUrl: "https://www.google.co.uk/"
+rootUrl: "http://example.com/"
 test: example

--- a/src/main/java/uk/gov/defra/tests/ExampleTest.java
+++ b/src/main/java/uk/gov/defra/tests/ExampleTest.java
@@ -17,13 +17,12 @@ public class ExampleTest extends BaseTest {
             driver.navigate().to(rootUrl);
 
             WebDriverWait wait = new WebDriverWait(driver, 10);
-            WebElement searchField = wait.until(ExpectedConditions.visibilityOfElementLocated(By.name("q")));
-            searchField.sendKeys("defra");
-            searchField.submit();
+            WebElement moreInfoLink = wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("a")));
 
-            WebElement firstResult = wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class=\"r\"]/a/h3")));
+            moreInfoLink.click();
+            WebElement ianaHeading = wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("h1")));
 
-            System.out.println(("First result: " + firstResult.getText()));
+            System.out.println(("Page heading: " + ianaHeading.getText()));
         } finally {
             driver.quit();
         }


### PR DESCRIPTION
The example test is used to check a new installation, and in Travis just to check we can actually run and hit a website. Recently though, the test is failing. After local testing its because the latest version of google chrome is throwing up a dialog about cookies. This appears to be regardless of whether automated testing is running, both normal and headless.

The dialog has broken our test, so we need to implement another, ideally on a page less likely to change than the Google home page.

<img width="658" alt="Screenshot 2020-10-02 at 15 21 52" src="https://user-images.githubusercontent.com/1789650/94934016-15742880-04c3-11eb-8f6d-bcc058a4a091.png">
