### PR TITLE
Switch to using GitHub actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,13 @@ jobs:
         run: |
           mvn clean package org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_sroc-tcm-acceptance-tests
 
+      - name: Install Chromedriver
+        run: |
+          CHROME_VERSION=$(google-chrome --version | cut -f 3 -d ' ' | cut -d '.' -f 1)
+          VERSION=$(curl --location --fail --retry 10 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION})
+          wget -c -nc --retry-connrefused --tries=0 https://chromedriver.storage.googleapis.com/${VERSION}/chromedriver_linux64.zip
+          unzip chromedriver_linux64.zip -d /home/runner/work/sroc-tcm-acceptance-tests/sroc-tcm-acceptance-tests/drivers
+
       - name: Run tests
         run: |
           java -jar target/sroc-tcm-acceptance-tests.jar example.config.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,29 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
+      # With maven already installed it should help build times by not running our local version (./mvnw).
+      # The actual maven command does a bunch of things
+      #
+      # - remove build time files
+      # - compile the code and package as a JAR
+      # - run unit tests
+      # - prepare test coverage information
+      # - install the JAR to the local repository (needed to ensure everything is up to date for SonarCloud)
+      # - run the SonarCloud analysis and send result to SonarCloud
       - name: Build with Maven
         run: |
           mvn clean package org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_sroc-tcm-acceptance-tests
 
+      # Both Chrome and chromedriver are available as part of ubuntu-latest
+      # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md#browsers-and-drivers
+      # Our issue is the project was setup to expect the chromedriver executable to be available in a specific place
+      # (drivers/). So for now we stick with what we did when using Travis for CI, updated based on code found in the
+      # setup-chromedriver action (https://github.com/nanasess/setup-chromedriver)
+      #
+      # - determine the currently installed version of Chrome
+      # - use curl to get the matching chromedriver version
+      # - use wget to download the chromedriver zip file
+      # - extract chromedriver to our drivers/ folder
       - name: Install Chromedriver
         run: |
           CHROME_VERSION=$(google-chrome --version | cut -f 3 -d ' ' | cut -d '.' -f 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TCM_TEST_PASSWORD: password
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       # Downloads a copy of the code in your repository before running CI tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on: push
+
+jobs:
+  build:
+    # You must use a Linux environment when using service containers or container jobs
+    runs-on: ubuntu-latest
+    env:
+      TCM_TEST_PASSWORD: password
+
+    steps:
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
+      # Our projects use .java-version files to specify the Java version to use. We can read and then output it as the
+      # result this step. Subsequent steps can then access the value
+      - name: Read Java version
+        run: echo "##[set-output name=JAVAV;]$(cat .java-version)"
+        # Give the step an ID to make it easier to refer to
+        id: jvm
+
+      # Gets the version to use by referring to the previous step
+      - name: Install Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: "${{ steps.jvm.outputs.JAVAV }}"
+
+      - name: Build with Maven
+        run: |
+          mvn clean package org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_sroc-tcm-acceptance-tests
+
+      - name: Run tests
+        run: |
+          java -jar target/sroc-tcm-acceptance-tests.jar example.config.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       # - run the SonarCloud analysis and send result to SonarCloud
       - name: Build with Maven
         run: |
-          mvn clean package org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_sroc-tcm-acceptance-tests
+          mvn clean package org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar
 
       # Both Chrome and chromedriver are available as part of ubuntu-latest
       # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md#browsers-and-drivers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@ jobs:
         with:
           java-version: "${{ steps.jvm.outputs.JAVAV }}"
 
+      # Speeds up workflows by reading the maven packages from cache. Obviously you need to run it at least once, and the
+      # the cache will be updated should the pom.xml file change
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
       - name: Build with Maven
         run: |
           mvn clean package org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_sroc-tcm-acceptance-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
           wget -c -nc --retry-connrefused --tries=0 https://chromedriver.storage.googleapis.com/${VERSION}/chromedriver_linux64.zip
           unzip chromedriver_linux64.zip -d /home/runner/work/sroc-tcm-acceptance-tests/sroc-tcm-acceptance-tests/drivers
 
-      - name: Run tests
+      # This runs an actual selenium test to confirm we haven't broken anything in the project and it should still be
+      # able to run against our own service.
+      - name: Run example test
         run: |
           java -jar target/sroc-tcm-acceptance-tests.jar example.config.yml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SROC TCM Acceptance tests
 
-[![Build Status](https://travis-ci.com/DEFRA/sroc-tcm-acceptance-tests.svg?branch=main)](https://travis-ci.com/DEFRA/sroc-tcm-acceptance-tests)
+![Build Status](https://github.com/DEFRA/sroc-tcm-acceptance-tests/workflows/CI/badge.svg?branch=main)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_sroc-tcm-acceptance-tests&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_sroc-tcm-acceptance-tests)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_sroc-tcm-acceptance-tests&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_sroc-tcm-acceptance-tests)
 [![Known Vulnerabilities](https://snyk.io/test/github/DEFRA/sroc-tcm-acceptance-tests/badge.svg)](https://snyk.io/test/github/DEFRA/sroc-tcm-acceptance-tests)
@@ -9,7 +9,7 @@
 > Temporary project. Do not use as a basis for doing selenium tests with Java!
 
 The Strategic Review of Charging (SROC) Tactical Charging Module (TCM) is an internal tool built by Defra to support the calculation of charges related to various permitting regimes.
- 
+
 This project contains the current acceptance tests for the TCM. It is built around [Selenium Webdriver](https://www.selenium.dev/documentation/en/webdriver/), a tool that allows you to programmatically 'drive' a browser.
 
 ## Prerequisites
@@ -30,7 +30,7 @@ git clone https://github.com/DEFRA/sroc-tcm-acceptance-tests.git
 cd sroc-tcm-acceptance-tests
 ```
 
-Then build the project using [Maven](https://maven.apache.org/). To simplify things the project comes with [maven-wrapper](https://github.com/takari/maven-wrapper). This will automatically install Maven for you if you don't already have it. 
+Then build the project using [Maven](https://maven.apache.org/). To simplify things the project comes with [maven-wrapper](https://github.com/takari/maven-wrapper). This will automatically install Maven for you if you don't already have it.
 
 ```bash
 ./mvnw clean install
@@ -89,7 +89,7 @@ test: main
 Key things are
 
 - `browser:` only use the values `chrome` or `firefox`
-- `headless:` only use the values `true` or `false`. 
+- `headless:` only use the values `true` or `false`.
 - `rootUrl:` should be the base url for an environment, not something like `https://url-of-tcm-dev-environment.gov.uk/auth/sign_in`
 - `test:` should always be `main`. It's configurable only to support the [Confirm setup](#confirm-setup) step of the installation.
 
@@ -121,7 +121,7 @@ The path can be absolute (`/Users/acruikshanks/sroc-tcm-acceptance-tests/dev.chr
 ## Here be dragons!
 
 The current team inherited the 'test' contained in this project. We were handed a single Java file containing 2.6K lines of code. Turns out it's a single `public static void main()` method (😱🤯) which uses Selenium to navigate the TCM.
-  
+
 No testing framework is referenced so there are no assertions. The 'test' was just *can I get through to the end without erroring*. Other highlights were
 
 - hardcoded paths for a specific user's machine

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,9 @@
         <maven.compile.target>1.7</maven.compile.target>
         <junit-jupiter-version>5.7.0</junit-jupiter-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.projectKey>DEFRA_sroc-tcm-acceptance-tests</sonar.projectKey>
+        <sonar.organization>defra</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
             <version>3.141.59</version>
         </dependency>
         <dependency>
+            <groupId>org.sonarsource.scanner.maven</groupId>
+            <artifactId>sonar-maven-plugin</artifactId>
+            <version>3.7.0.1746</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit-jupiter-version}</version>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,8 +6,8 @@ sonar.organization=defra
 sonar.projectName=sroc-tcm-acceptance-tests
 
 # This will add the same links in the SonarCloud UI
-sonar.links.homepage=https://github.com/DEFRA/sroc-service-team
-sonar.links.ci=https://travis-ci.com/DEFRA/sroc-tcm-acceptance-tests
+sonar.links.homepage=https://github.com/DEFRA/sroc-tcm-acceptance-tests
+sonar.links.ci=https://github.com/DEFRA/sroc-tcm-acceptance-tests/actions
 sonar.links.scm=https://github.com/DEFRA/sroc-tcm-acceptance-tests
 sonar.links.issue=https://github.com/DEFRA/sroc-service-team/issues
 


### PR DESCRIPTION
https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works

On Nov 2 Travis-CI introduced a new pricing model for their free tier offering. Those on this tier would now be limited to 1000 build minutes a month. This would start to be rolled out across accounts imminently. Defra's seems to have been updated November 9 because by the end of the day all builds stopped. When you went to Travis-CI a message was shown stating

> Builds have been temporarily disabled for private and public repositories due to a negative credit balance. Please go to the Plan page to replenish your credit balance.

It's going to take some time to decide and agree whether we will move to a paid-for option, or choose to start rolling our own. We don't like the idea of having no automated CI during this unknown period. A number of people caught up in this change have suggested [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions) as an alternative.

So this change moves the project from Travis to GitHub to handle our CI