### PR TITLE
Change test user to admin@sroc.gov.uk

### DIFF
--- a/src/main/java/uk/gov/defra/tests/MainTest.java
+++ b/src/main/java/uk/gov/defra/tests/MainTest.java
@@ -50,7 +50,7 @@ public class MainTest extends BaseTest {
 
             wait = new WebDriverWait(driver, 15);
             wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("user_email")));
-            driver.findElement(By.id("user_email")).sendKeys("tacticalcm+1@gmail.com");
+            driver.findElement(By.id("user_email")).sendKeys("admin@sroc.gov.uk");
 
             // Type in password
             driver.findElement(By.id("user_password")).sendKeys(password);


### PR DESCRIPTION
Across the environments, we found that `tacticalcm+1@gmail.com` may be configured differently. It's also something that has to be manually created. `admin@sroc.gov.uk` is seeded by the project and has been set up consistently across the environments. So to make the test more stable and consistent wherever we run it, this changes the user for the test to one dedicated to acceptance testing.